### PR TITLE
fix: prevent fragment FOUC by awaiting load before section reveal

### DIFF
--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -71,35 +71,35 @@ async function loadFonts() {
 /** Hash that opts out of fragment auto-blocking (do not block). Links with #_dnb stay as normal links. */
 const DNB_HASH = '#_dnb';
 
+async function loadFragments(section) {
+  const main = section.closest('main');
+  const links = [...section.querySelectorAll('a[href*="/fragments/"]')]
+    .filter((a) => !a.closest('.fragment'));
+  const fragments = links.filter((a) => {
+    if (a.href.includes(DNB_HASH)) {
+      a.href = a.href.replace(DNB_HASH, '').replace(/#$/, '');
+      return false;
+    }
+    return true;
+  });
+  if (fragments.length === 0) return;
+  const { loadFragment } = await import('../blocks/fragment/fragment.js');
+  await Promise.all(fragments.map(async (a) => {
+    try {
+      const { pathname } = new URL(a.href);
+      const frag = await loadFragment(pathname);
+      a.parentElement.replaceWith(...frag.children);
+    } catch (error) {
+      console.error('Fragment loading failed', error);
+    }
+  }));
+  await dynamicBlocks(main);
+}
+
 function buildAutoBlocks(main) {
   try {
-    // auto load `*/fragments/*` references (exclude #_dnb = do not auto-block)
-    const allFragments = [...main.querySelectorAll('a[href*="/fragments/"]')].filter((f) => !f.closest('.fragment'));
-    const fragments = allFragments.filter((a) => {
-      if (a.href.includes(DNB_HASH)) {
-        a.href = a.href.replace(DNB_HASH, '').replace(/#$/, '');
-        return false;
-      }
-      return true;
-    });
-    if (fragments.length > 0) {
-      import('../blocks/fragment/fragment.js').then(({ loadFragment }) => {
-        fragments.forEach(async (fragment) => {
-          try {
-            const { pathname } = new URL(fragment.href);
-            const frag = await loadFragment(pathname);
-            fragment.parentElement.replaceWith(...frag.children);
-            await dynamicBlocks(main);
-          } catch (error) {
-
-            console.error('Fragment loading failed', error);
-          }
-        });
-      });
-    }
     buildEmbedBlocks(main);
   } catch (error) {
-     
     console.error('Auto Blocking failed', error);
   }
 }
@@ -174,7 +174,10 @@ async function loadEager(doc) {
     if (window.isErrorPage) loadErrorPage(main);
     decorateMain(main);
     document.body.classList.add('appear');
-    await loadSection(main.querySelector('.section'), waitForFirstImage);
+    await loadSection(main.querySelector('.section'), async (s) => {
+      await loadFragments(s);
+      await waitForFirstImage(s);
+    });
   }
 
   try {
@@ -198,8 +201,10 @@ async function loadLazy(doc) {
 
   const main = doc.querySelector('main');
   const sections = main ? [...main.querySelectorAll('div.section')] : [];
-  await Promise.all(sections.map((s) => loadSection(s)));
-  if (sections[0] && sampleRUM.enhance) sampleRUM.enhance();
+  for (let i = 0; i < sections.length; i += 1) {
+    await loadSection(sections[i], loadFragments);
+    if (i === 0 && sampleRUM.enhance) sampleRUM.enhance();
+  }
   await dynamicBlocks(main);
 
   const { hash } = window.location;


### PR DESCRIPTION
## Summary
- Move fragment loading from fire-and-forget in `buildAutoBlocks` to an awaitable `loadFragments(section)` callback passed to `loadSection`
- Sections now wait for fragment content to load before becoming visible, preventing bare link flash
- Restore sequential section loading (top-to-bottom) per boilerplate standard, replacing parallel `Promise.all` approach introduced in c455bed

> **Stacked on** #76 — merge that first.

## Test plan
- [ ] Verify pages with auto-blocked fragments no longer flash bare links before content loads
- [ ] Verify sections still reveal top-to-bottom sequentially
- [ ] Verify `#_dnb` opt-out still works
- [ ] Verify fragment block (non-auto-blocked) still works
- [ ] Run PageSpeed on preview URL

**Before/after**: https://fix-fragment-fouc--diyfire--cloudadoption.aem.page

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>